### PR TITLE
Enable CMSIS-DAP over USB

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ arm-none-eabi-gdb firmware.elf
 
 When connected via USB, the device appears as a CMSIS-DAP interface compatible with pyOCD and most IDEs (VS Code Cortex-Debug, Keil, IAR).
 
+When Port C is configured for SWD/JTAG, only one of the two debug paths is active at a time — the BMP GDB server or the USB CMSIS-DAP interface (mutual exclusion). Disable the USB DAP via the **Disable USB DAP** option on the dashboard when you want to use the built-in BMP GDB server instead.
+
 ### XVC (Vivado Virtual Cable)
 
 For FPGA development, configure Port D to **XVC** mode. Then connect Vivado to `<device-ip>:2542`.

--- a/main/main.c
+++ b/main/main.c
@@ -1048,7 +1048,16 @@ static void draw_port_cfg_info(void)
 /* Start background tasks (GDB, logic analyser, XVC). */
 static void start_background_tasks(void)
 {
-    if (gbl_pc_cfg == PC_BMP_SWD_JTAG) {
+    bool usb_dap_enabled = false;
+    {
+        char *val = NULL;
+        if (storage_alloc_and_read(DISABLE_USB_DAP_KEY, &val) == ESP_OK && val) {
+            usb_dap_enabled = (strcmp(val, "1") != 0);
+            free(val);
+        }
+    }
+
+    if (gbl_pc_cfg == PC_BMP_SWD_JTAG && !usb_dap_enabled) {
         ESP_LOGI(TAG, "Creating gdb_thread task. gbl_pa_cfg=%d, gbl_pc_cfg=%d", gbl_pa_cfg, gbl_pc_cfg);
         ESP_LOGI(TAG, "Free heap: %u", esp_get_free_heap_size());
         ESP_LOGI(TAG, "To do platform_init() for BMP");
@@ -1058,6 +1067,8 @@ static void start_background_tasks(void)
         if (result != pdPASS) {
             ESP_LOGE(TAG, "Failed to create gdb_thread task! Out of memory?");
         }
+    } else if (gbl_pc_cfg == PC_BMP_SWD_JTAG && usb_dap_enabled) {
+        ESP_LOGI(TAG, "USB CMSIS-DAP enabled — skipping BMP gdb_thread (mutual exclusion)");
     }
 
     if (g_board->has_logic_analyzer) {

--- a/main/network/web_server.c
+++ b/main/network/web_server.c
@@ -898,16 +898,17 @@ esp_err_t set_credentials_handler(httpd_req_t *req) {
         }
     }
 
-    // UART Port Selection is fixed to 1 (Web Terminal) — ignore incoming value
-    {
+    // Check if UART Port selection changed (requires reboot)
+    if (uartPortSel_str) {
         char *stored_uart_psel = NULL;
         if (storage_alloc_and_read(UART_PORT_SEL_KEY, &stored_uart_psel) == ESP_OK && stored_uart_psel) {
-            if (strcmp(stored_uart_psel, "1") != 0) {
-                ESP_LOGI(TAG, "UART Port Selection forced to Web Terminal (was %s)", stored_uart_psel);
+            if (strcmp(stored_uart_psel, uartPortSel_str) != 0) {
+                ESP_LOGI(TAG, "UART Port changed: %s -> %s", stored_uart_psel, uartPortSel_str);
                 reboot_required = true;
             }
             free(stored_uart_psel);
         } else {
+            ESP_LOGI(TAG, "UART Port set for the first time: %s", uartPortSel_str);
             reboot_required = true;
         }
     }
@@ -920,17 +921,18 @@ esp_err_t set_credentials_handler(httpd_req_t *req) {
         reboot_required = true;
     }
 
-    // Disable USB DAP is fixed to true — ignore incoming value
+    // Check if USB DAP setting changed (requires reboot)
     {
         char *stored_disable_dap = NULL;
         if (storage_alloc_and_read(DISABLE_USB_DAP_KEY, &stored_disable_dap) == ESP_OK && stored_disable_dap) {
-            if (strcmp(stored_disable_dap, "1") != 0) {
-                ESP_LOGI(TAG, "Disable USB DAP forced to enabled (was %s)", stored_disable_dap);
+            bool stored_val = (strcmp(stored_disable_dap, "1") == 0);
+            if (stored_val != disableUsbDapCom_val) {
+                ESP_LOGI(TAG, "USB DAP setting changed: %d -> %d", stored_val, disableUsbDapCom_val);
                 reboot_required = true;
             }
             free(stored_disable_dap);
         } else {
-            ESP_LOGI(TAG, "Disable USB DAP set for the first time (forced enabled).");
+            ESP_LOGI(TAG, "USB DAP setting first time: %d", disableUsbDapCom_val);
             reboot_required = true;
         }
     }
@@ -958,8 +960,11 @@ esp_err_t set_credentials_handler(httpd_req_t *req) {
         if (uartDataBits_str) storage_write_session(h, UART_DATA_BITS_KEY, uartDataBits_str, strlen(uartDataBits_str));
         if (uartStopBits_str) storage_write_session(h, UART_STOP_BITS_KEY, uartStopBits_str, strlen(uartStopBits_str));
         if (uartParity_str) storage_write_session(h, UART_PARITY_KEY, uartParity_str, strlen(uartParity_str));
-        storage_write_session(h, UART_PORT_SEL_KEY, "1", 1);
-        storage_write_session(h, DISABLE_USB_DAP_KEY, "1", 1);
+        if (uartPortSel_str) storage_write_session(h, UART_PORT_SEL_KEY, uartPortSel_str, strlen(uartPortSel_str));
+        {
+            const char *dap_val = disableUsbDapCom_val ? "1" : "0";
+            storage_write_session(h, DISABLE_USB_DAP_KEY, dap_val, strlen(dap_val));
+        }
 
         storage_close_session(h);
     }
@@ -1088,9 +1093,16 @@ esp_err_t get_credentials_handler(httpd_req_t *req) {
          cJSON_AddStringToObject(root, "otaUrl", "");
     }
 
-    // Fixed values: MCU interface is always GPIO, UART always Web Terminal
+    // MCU interface is always GPIO
     cJSON_AddStringToObject(root, "mcuInterface", "GPIO");
-    cJSON_AddStringToObject(root, "uartPortSel", "1");
+
+    // UART port selection: 0=USB, 1=Web Terminal
+    if (storage_alloc_and_read(UART_PORT_SEL_KEY, &val) == ESP_OK && val) {
+        cJSON_AddStringToObject(root, "uartPortSel", val);
+        free(val); val = NULL;
+    } else {
+        cJSON_AddStringToObject(root, "uartPortSel", "1");
+    }
 
     // --- UART Settings ---
     if (storage_alloc_and_read(UART_BAUD_KEY, &val) == ESP_OK && val) {
@@ -1121,8 +1133,13 @@ esp_err_t get_credentials_handler(httpd_req_t *req) {
         cJSON_AddStringToObject(root, "uartParity", "n"); // 'n' for None
     }
 
-    // Fixed value: USB DAP/COM is always disabled
-    cJSON_AddBoolToObject(root, "disableUsbDapCom", true);
+    // USB DAP/COM enabled state: read from NVS
+    if (storage_alloc_and_read(DISABLE_USB_DAP_KEY, &val) == ESP_OK && val) {
+        cJSON_AddBoolToObject(root, "disableUsbDapCom", strcmp(val, "1") == 0);
+        free(val); val = NULL;
+    } else {
+        cJSON_AddBoolToObject(root, "disableUsbDapCom", true);
+    }
 
     const char *sys_info = cJSON_PrintUnformatted(root);
     httpd_resp_sendstr(req, sys_info);

--- a/main/web/website.html
+++ b/main/web/website.html
@@ -462,6 +462,28 @@
         </div>
 -->
       <div class="panel">
+        <h3>USB CMSIS-DAP</h3>
+        <div style="margin-top: 8px; line-height: 2.0;">
+          <label style="display: flex; align-items: center; gap: 10px;">
+            <input type="checkbox" id="enable-usb-dap">
+            <span>Enable USB CMSIS-DAP</span>
+          </label>
+          <p style="font-size: 0.85em; color: #666; margin: 8px 0 0 0;">
+            Checked: Use CMSIS-DAP over USB (disables WiFi BMP debug).<br>
+            Unchecked: Use WiFi BMP for debugging (default).<br>
+            <b>Changing this requires a reboot.</b>
+          </p>
+          <label style="display: flex; align-items: center; gap: 20px; margin-top: 10px;">
+            <span>UART Port:</span>
+            <select id="uart-port-sel">
+              <option value="0">USB (CDC ACM)</option>
+              <option value="1">Web Terminal</option>
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <div class="panel">
         <h3>Wi-Fi Configuration</h3>
         <div style="display: flex; align-items: center; gap: 15px; margin-bottom: 15px;">
           <label style="width: 100px;">WiFi Mode</label>
@@ -754,8 +776,8 @@
         if (data.uartDataBits) document.getElementById("uart-dbits").value = data.uartDataBits;
         if (data.uartStopBits) document.getElementById("uart-sbits").value = data.uartStopBits;
         if (data.uartParity) document.getElementById("uart-parity").value = data.uartParity;
-
-        // disableUsbDapCom is fixed — not loaded from server
+        if (data.uartPortSel) document.getElementById("uart-port-sel").value = data.uartPortSel;
+        if (typeof data.disableUsbDapCom !== 'undefined') document.getElementById("enable-usb-dap").checked = !data.disableUsbDapCom;
       }
 
 
@@ -885,10 +907,12 @@
         var otaUrlElem = document.getElementById("ota-url");
         var otaUrl = otaUrlElem ? otaUrlElem.value : "";
 
-        // Fixed values: not user-configurable
+        // MCU interface is always GPIO
         var mcuInterface = "GPIO";
 
-        var disableUsbDapCom = true;
+        // USB CMSIS-DAP: checked = enable (disableUsbDapCom = false)
+        var enableUsbDap = document.getElementById("enable-usb-dap").checked;
+        var disableUsbDapCom = !enableUsbDap;
 
         // Validation: SSID required for Station Mode
         if (wifiMode === "SM" && ssid === "") {
@@ -903,8 +927,8 @@
           return;
         }
 
-        // Fixed value: not user-configurable
-        var uartPortSel = "1";
+        // UART port selection: 0=USB, 1=Web Terminal
+        var uartPortSel = document.getElementById("uart-port-sel").value;
 
         var systemConfigJson = {
           pacfg: pacfg,


### PR DESCRIPTION
Add USB CMSIS-DAP enable/disable support alongside the existing WiFi-based BMP debug mode. The two modes are mutually exclusive.

- Web UI: USB CMSIS-DAP enable checkbox, UART port select (USB/Web)
- Web server: read/write DISABLE_USB_DAP_KEY and UART_PORT_SEL_KEY from NVS
- Backend: skip BMP gdb_thread when CMSIS-DAP is enabled