### PR TITLE
Add OTA partition management and reboot-to-bootloader help screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ What makes ESP32JTAG especially distinctive is its ability to work seamlessly wi
   - WiFi AP mode (standalone hotspot) or STA mode (connects to existing network)
   - WiFi provisioning
   - OTA firmware updates over HTTPS
+  - OTA partition management — view OTA status, switch between `ota_0` / `ota_1` from the web UI
   - WebSocket bridge for UART traffic
 
 - **Web Interface**
@@ -55,6 +56,7 @@ What makes ESP32JTAG especially distinctive is its ability to work seamlessly wi
   - Debugger target / RTOS / interface selection
   - Port A/B/C/D mode configuration
   - SRESET polarity (active HIGH / active LOW) and pulse width (1–5000 ms) configuration — applied without reboot via `POST /api/sreset_config`
+  - Reboot into ROM bootloader mode from the web UI (`POST /reboot_bootloader`)
 
 - **Signal Generation (Port D)**
   - Provides signal stimulus to the target system via Port D pins
@@ -192,6 +194,20 @@ The filename encodes version, UTC build timestamp, and git commit so you can alw
 2. Select the `_ota.bin` file and click **Upload & Update**.
 3. The device reboots automatically into the new firmware.
 
+OTA updates use two partitions (`ota_0` / `ota_1`). After an update, you can:
+- View the running and alternate partition from the web UI (`/api/ota_status`).
+- Roll back to the previous firmware by clicking **Switch to Alternate Partition** (`/switch_ota_partition`) — useful if a new build misbehaves.
+
+### Reboot to Bootloader (reflash mode)
+
+From the web UI you can reboot the device into ROM bootloader mode (`/reboot_bootloader`). This is useful when the firmware is not booting properly, when the serial port is unavailable (CMSIS-DAP USB mode), or when flashing via esptool instead of OTA.
+
+After the reboot, enter download mode by holding **BOOT0** (SW1) while powering up, or run:
+```bash
+esptool.py --chip esp32s3 -p /dev/ttyUSB0 --before default-reset run
+```
+then flash with esptool as described below.
+
 ### Firmware Update — USB flash (factory / first-time programming)
 
 ```bash
@@ -256,6 +272,9 @@ After connecting to the AP (or the local network in STA mode), open a browser an
 | `/credentials` | Change web UI username and password |
 | `/ota_upload` | Upload new firmware |
 | `/reset_to_factory` | Erase all NVS settings and reboot |
+| `/reboot_bootloader` | Reboot into ROM bootloader (reflash) mode |
+| `/switch_ota_partition` | Switch to the alternate OTA partition and reboot |
+| `/api/ota_status` | OTA partition status (running + alternate labels) |
 
 ### Debugger Configuration
 

--- a/main/network/web_server.c
+++ b/main/network/web_server.c
@@ -1951,6 +1951,133 @@ httpd_uri_t uri_reset_to_factory = {
     .user_ctx  = NULL
 };
 
+static esp_err_t reboot_bootloader_handler(httpd_req_t *req) {
+    if (check_auth(req) != ESP_OK) return ESP_OK;
+    ESP_LOGW(TAG, "Reboot to bootloader requested");
+    httpd_resp_sendstr(req, "Rebooting. After reboot, use esptool with --before default-reset to enter bootloader mode, or hold SW1 (BOOT0) during power-up.");
+    vTaskDelay(2000 / portTICK_PERIOD_MS);
+    esp_restart();
+    return ESP_OK;
+}
+
+httpd_uri_t uri_reboot_bootloader = {
+    .uri       = "/reboot_bootloader",
+    .method    = HTTP_POST,
+    .handler   = reboot_bootloader_handler,
+    .user_ctx  = NULL
+};
+
+static esp_err_t switch_ota_partition_handler(httpd_req_t *req) {
+    if (check_auth(req) != ESP_OK) return ESP_OK;
+
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    const esp_partition_t *next = esp_ota_get_next_update_partition(NULL);
+
+    if (!running || !next) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Cannot get OTA partitions");
+        return ESP_FAIL;
+    }
+
+    if (running == next) {
+        httpd_resp_sendstr(req, "No alternate OTA partition available.");
+        return ESP_OK;
+    }
+
+    ESP_LOGW(TAG, "Switching OTA partition: %s -> %s", running->label, next->label);
+    esp_err_t err = esp_ota_set_boot_partition(next);
+    if (err != ESP_OK) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to set boot partition");
+        return ESP_FAIL;
+    }
+
+    httpd_resp_sendstr(req, "Switched OTA partition. Rebooting...");
+    vTaskDelay(2000 / portTICK_PERIOD_MS);
+    esp_restart();
+    return ESP_OK;
+}
+
+httpd_uri_t uri_switch_ota = {
+    .uri       = "/switch_ota_partition",
+    .method    = HTTP_POST,
+    .handler   = switch_ota_partition_handler,
+    .user_ctx  = NULL
+};
+
+static esp_err_t ota_status_handler(httpd_req_t *req) {
+    if (check_auth(req) != ESP_OK) return ESP_OK;
+
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    const esp_partition_t *next = esp_ota_get_next_update_partition(NULL);
+
+    cJSON *root = cJSON_CreateObject();
+    if (!root) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Out of memory");
+        return ESP_FAIL;
+    }
+
+    if (running) {
+        cJSON *cur = cJSON_CreateObject();
+        if (cur) {
+            cJSON_AddStringToObject(cur, "label", running->label);
+            esp_app_desc_t desc;
+            if (esp_ota_get_partition_description(running, &desc) == ESP_OK) {
+                cJSON_AddStringToObject(cur, "version", desc.version);
+                cJSON_AddStringToObject(cur, "date", desc.date);
+                cJSON_AddStringToObject(cur, "time", desc.time);
+                char sha[8] = {0};
+                for (int i = 0; i < 3; i++)
+                    snprintf(sha + i*2, 3, "%02x", desc.app_elf_sha256[i]);
+                cJSON_AddStringToObject(cur, "commit", sha);
+            } else {
+                cJSON_AddStringToObject(cur, "version", "unknown");
+            }
+            cJSON_AddItemToObject(root, "current", cur);
+        }
+    }
+
+    if (next) {
+        cJSON *nxt = cJSON_CreateObject();
+        if (nxt) {
+            cJSON_AddStringToObject(nxt, "label", next->label);
+            esp_app_desc_t desc;
+            if (esp_ota_get_partition_description(next, &desc) == ESP_OK) {
+                cJSON_AddStringToObject(nxt, "version", desc.version);
+                cJSON_AddStringToObject(nxt, "date", desc.date);
+                cJSON_AddStringToObject(nxt, "time", desc.time);
+                char sha[8] = {0};
+                for (int i = 0; i < 3; i++)
+                    snprintf(sha + i*2, 3, "%02x", desc.app_elf_sha256[i]);
+                cJSON_AddStringToObject(nxt, "commit", sha);
+            } else {
+                cJSON_AddStringToObject(nxt, "version", "empty");
+            }
+            cJSON_AddItemToObject(root, "alternate", nxt);
+            cJSON_AddBoolToObject(root, "has_alternate", true);
+        }
+    } else {
+        cJSON_AddBoolToObject(root, "has_alternate", false);
+    }
+
+    char *json_str = cJSON_PrintUnformatted(root);
+    if (!json_str) {
+        cJSON_Delete(root);
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to serialize JSON");
+        return ESP_FAIL;
+    }
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, json_str);
+    free(json_str);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+httpd_uri_t uri_ota_status = {
+    .uri       = "/api/ota_status",
+    .method    = HTTP_GET,
+    .handler   = ota_status_handler,
+    .user_ctx  = NULL
+};
+
 httpd_uri_t uri_ota_upload = {
     .uri      = "/ota_upload",
     .method   = HTTP_POST,
@@ -2257,7 +2384,7 @@ esp_err_t web_server_start(httpd_handle_t *http_handle) {
     config.prvtkey_pem = prvtkey_buf;
     config.prvtkey_len = prvtkey_len + 1; // Include null terminator
 
-    config.httpd.max_uri_handlers = 30;
+    config.httpd.max_uri_handlers = 45;
     config.httpd.stack_size = 10240; // Increased stack for SSL operations
 
     ESP_LOGI(TAG, "Starting HTTPS Server on port: '%d'", config.httpd.server_port);
@@ -2279,6 +2406,9 @@ esp_err_t web_server_start(httpd_handle_t *http_handle) {
     httpd_register_uri_handler(*http_handle, &uri_log_error);
     httpd_register_uri_handler(*http_handle, &uri_ota_upload);
     httpd_register_uri_handler(*http_handle, &uri_reset_to_factory);
+    httpd_register_uri_handler(*http_handle, &uri_reboot_bootloader);
+    httpd_register_uri_handler(*http_handle, &uri_switch_ota);
+    httpd_register_uri_handler(*http_handle, &uri_ota_status);
 
     httpd_register_err_handler(*http_handle, HTTPD_404_NOT_FOUND, not_found_handler);
     ESP_ERROR_CHECK(uart_websocket_add_handlers(*http_handle));

--- a/main/web/website.html
+++ b/main/web/website.html
@@ -494,13 +494,6 @@
             </label>
           </div>
         </div>
-        <!--
-        <div style="display: flex; align-items: center; gap: 20px; margin-bottom: 15px;">
-          <label for="ota-url" style="display: inline-block; width: 100px;">OTA URL</label>
-          <input type="text" id="ota-url" placeholder="http://example.com/firmware.bin">
-        </div>
-      </div>
--->
       </div>
 
       <div class="panel">
@@ -531,6 +524,12 @@
         <div style="margin-top: 10px;">
           <button type="button" onclick="setToDefault()">Set to default</button>
           <button type="button" onclick="sendCredentials()">Save settings & Restart</button>
+        </div>
+        <div style="margin-top: 15px; padding-top: 10px; border-top: 1px solid #ddd;">
+          <p style="font-size: 0.82em; color: #666; margin: 0 0 8px 0;">
+            "Reboot to Bootloader" reboots the ESP32JTAG and attempts to enter reflash boot mode. After reboot, run <code>esptool --port /dev/ttyACM0 --chip esp32s3 --before default-reset run</code> to trigger download mode, or hold the BOOT0 button (SW1) while powering up the device, then release it. This is needed when using CMSIS-DAP USB mode (serial port unavailable), when the firmware is not booting properly, or when flashing via esptool instead of OTA.
+          </p>
+          <button type="button" onclick="rebootBootloader()" style="background: #e74c3c; color: white;">Reboot to Bootloader</button>
         </div>
       </div>
 
@@ -567,6 +566,21 @@
       </div>
       <div id="ota-status" style="display:none; margin:10px 0; padding:10px 14px; border-radius:5px; font-size:0.95em;"></div>
       <button type="button" id="ota-upload-button" disabled onclick="uploadOtaFirmware()">Upload & Update</button>
+
+      <div style="margin-top: 20px; border-top: 1px solid #ddd; padding-top: 15px;">
+        <div id="ota-partition-info" style="font-family: monospace; font-size: 0.88em; margin-bottom: 10px; color: #222;">
+          Loading partition info...
+        </div>
+        <div style="display: flex; gap: 10px; flex-wrap: wrap;">
+          <button type="button" onclick="switchOtaPartition()" style="background: #f39c12; color: white;">Switch to Alternate Partition</button>
+        </div>
+        <div style="margin-top: 15px; padding-top: 10px; border-top: 1px solid #ddd;">
+          <p style="font-size: 0.82em; color: #666; margin: 0 0 8px 0;">
+            "Reboot to Bootloader" reboots the ESP32JTAG and attempts to enter reflash boot mode. After reboot, run <code>esptool --port /dev/ttyACM0 --chip esp32s3 --before default-reset run</code> to trigger download mode, or hold the BOOT0 button (SW1) while powering up the device, then release it. This is needed when using CMSIS-DAP USB mode (serial port unavailable), when the firmware is not booting properly, or when flashing via esptool instead of OTA.
+          </p>
+          <button type="button" onclick="rebootBootloader()" style="background: #e74c3c; color: white;">Reboot to Bootloader</button>
+        </div>
+      </div>
     </form>
     <footer>
       <span>&copy; EZ32 Technologies Inc. &nbsp;<a href="https://www.ez32.com" target="_blank" rel="noopener">www.ez32.com</a></span>
@@ -1197,6 +1211,51 @@
             }
           })
           .catch(function() {});
+        loadOtaPartitionInfo();
+      }
+
+      function loadOtaPartitionInfo() {
+        fetch('/api/ota_status')
+          .then(function(r) { return r.ok ? r.json() : null; })
+          .then(function(d) {
+            if (!d) return;
+            var el = document.getElementById('ota-partition-info');
+            if (!el) return;
+            var html = '';
+            if (d.current) {
+              html += '<b>Current:</b> ' + d.current.label +
+                ' &mdash; v' + d.current.version;
+              if (d.current.date && d.current.commit) {
+                html += ' (build ' + d.current.date + ' ' + d.current.time +
+                  ' commit ' + d.current.commit + ')';
+              }
+              html += '<br>';
+            }
+            if (d.has_alternate && d.alternate) {
+              html += '<b>Alternate:</b> ' + d.alternate.label +
+                ' &mdash; v' + d.alternate.version;
+              if (d.alternate.date && d.alternate.commit) {
+                html += ' (build ' + d.alternate.date + ' ' + d.alternate.time +
+                  ' commit ' + d.alternate.commit + ')';
+              }
+            } else {
+              html += '<b>Alternate:</b> none';
+            }
+            el.innerHTML = html;
+          })
+          .catch(function() {});
+      }
+
+      function rebootBootloader() {
+        if (!confirm('Reboot into ROM bootloader mode? You will need esptool to flash new firmware.')) return;
+        showRebootCountdown('Entering bootloader mode...', 5);
+        fetch('/reboot_bootloader', { method: 'POST' }).catch(function() {});
+      }
+
+      function switchOtaPartition() {
+        if (!confirm('Switch to the other OTA partition and reboot?')) return;
+        showRebootCountdown('Switching OTA partition...', 5);
+        fetch('/switch_ota_partition', { method: 'POST' }).catch(function() {});
       }
 
       let ws;


### PR DESCRIPTION
OTA partition management:
- Switch between OTA partitions via web UI
- View OTA status (running partition, version info)
- Backend handlers for partition switching and status API

Reboot-to-bootloader help screen:
- Reboot into ROM bootloader mode from web UI
- Confirmation dialog and countdown before reboot